### PR TITLE
Bug/em 3045 document outline dest fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ build/
 *.iml
 src/main/generated/
 bin/test/
+target/
 

--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/BundleOutlineScenarios.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/BundleOutlineScenarios.java
@@ -33,14 +33,10 @@ public class BundleOutlineScenarios extends BaseTest {
 
         final PDOutlineItem bundleOutline = stitchedOutline.getFirstChild();
 
-        Assert.assertEquals(bundleOutline.getTitle(),
-                "Bundle Title");
-        Assert.assertEquals(bundleOutline.getFirstChild().getTitle(),
-                "Index Page");
-        Assert.assertEquals(bundleOutline.getFirstChild().getNextSibling().getTitle(),
-                "Title (Document 1)");
-        Assert.assertEquals(bundleOutline.getFirstChild().getNextSibling().getNextSibling().getTitle(),
-                "Title (Document 2)");
+        Assert.assertEquals(bundleOutline.getTitle(), "Bundle Title");
+        Assert.assertEquals(bundleOutline.getNextSibling().getTitle(), "Index Page");
+        Assert.assertEquals(bundleOutline.getNextSibling().getNextSibling().getTitle(), "Title (Document 1)");
+        Assert.assertEquals(bundleOutline.getNextSibling().getNextSibling().getNextSibling().getTitle(), "Title (Document 2)");
     }
 
     @Test
@@ -57,13 +53,10 @@ public class BundleOutlineScenarios extends BaseTest {
 
         final PDOutlineItem bundleOutline = stitchedOutline.getFirstChild();
 
-        Assert.assertEquals(bundleOutline.getTitle(),
-                "Bundle Title");
-        Assert.assertEquals(bundleOutline.getFirstChild().getTitle(),
-                "Index Page");
-        Assert.assertEquals(bundleOutline.getFirstChild().getNextSibling().getTitle(),
-                "Title (Document 1)");
-        Assert.assertEquals(bundleOutline.getFirstChild().getNextSibling().getFirstChild().getTitle(),
+        Assert.assertEquals(bundleOutline.getTitle(), "Bundle Title");
+        Assert.assertEquals(bundleOutline.getNextSibling().getTitle(), "Index Page");
+        Assert.assertEquals(bundleOutline.getNextSibling().getNextSibling().getTitle(), "Title (Document 1)");
+        Assert.assertEquals(bundleOutline.getNextSibling().getNextSibling().getNextSibling().getTitle(),
                 documentOutline.getFirstChild().getTitle());
     }
 
@@ -84,15 +77,15 @@ public class BundleOutlineScenarios extends BaseTest {
 
         Assert.assertEquals(bundleOutline.getTitle(),
                 "Bundle with folders");
-        Assert.assertEquals(bundleOutline.getFirstChild().getTitle(),
+        Assert.assertEquals(bundleOutline.getNextSibling().getTitle(),
                 "Index Page");
-        Assert.assertEquals(bundleOutline.getFirstChild().getNextSibling().getTitle(),
+        Assert.assertEquals(bundleOutline.getNextSibling().getNextSibling().getTitle(),
                 "Folder 1");
-        Assert.assertEquals(bundleOutline.getFirstChild().getNextSibling().getFirstChild().getTitle(),
+        Assert.assertEquals(bundleOutline.getNextSibling().getNextSibling().getNextSibling().getTitle(),
                 "Title (Document1.pdf)");
-        Assert.assertEquals(bundleOutline.getFirstChild().getNextSibling().getNextSibling().getTitle(),
+        Assert.assertEquals(bundleOutline.getNextSibling().getNextSibling().getNextSibling().getNextSibling().getTitle(),
                 "Folder 2");
-        Assert.assertEquals(bundleOutline.getFirstChild().getNextSibling().getNextSibling().getFirstChild().getTitle(),
+        Assert.assertEquals(bundleOutline.getNextSibling().getNextSibling().getNextSibling().getNextSibling().getNextSibling().getTitle(),
                 "Title (Document2.pdf)");
     }
 
@@ -111,27 +104,24 @@ public class BundleOutlineScenarios extends BaseTest {
 
         PDOutlineItem bundleOutline = stitchedOutline.getFirstChild();
 
-        Assert.assertEquals(bundleOutline.getTitle(),
-                "Bundle with folders");
-        Assert.assertEquals(bundleOutline.getFirstChild().getTitle(),
-                "Index Page");
-        Assert.assertEquals(bundleOutline.getFirstChild().getNextSibling().getTitle(),
-                "Folder 1");
+        Assert.assertEquals(bundleOutline.getTitle(), "Bundle with folders");
+        Assert.assertEquals(bundleOutline.getNextSibling().getTitle(), "Index Page");
+        Assert.assertEquals(bundleOutline.getNextSibling().getNextSibling().getTitle(), "Folder 1");
 
-        bundleOutline = bundleOutline.getFirstChild().getNextSibling();
+        bundleOutline = bundleOutline.getNextSibling().getNextSibling();
 
-        Assert.assertEquals(bundleOutline.getFirstChild().getTitle(),
-                "Title (Document1.pdf)");
-        Assert.assertEquals(bundleOutline.getFirstChild().getNextSibling().getTitle(),
-                "Folder 1a");
-        Assert.assertEquals(bundleOutline.getFirstChild().getNextSibling().getFirstChild().getTitle(),
-                "Title (Document1a.pdf)");
-        Assert.assertEquals(bundleOutline.getFirstChild().getNextSibling().getNextSibling().getTitle(),
-                "Folder 1b");
-        Assert.assertEquals(bundleOutline.getFirstChild().getNextSibling().getNextSibling().getFirstChild().getTitle(),
-                "Title (Document1b.pdf)");
-        Assert.assertEquals(bundleOutline.getNextSibling().getTitle(),
-                "Folder 2");
+        Assert.assertEquals(bundleOutline.getNextSibling().getTitle(), "Title (Document1.pdf)");
+        Assert.assertEquals(bundleOutline.getNextSibling().getNextSibling().getTitle(), "Folder 1a");
+
+        bundleOutline = bundleOutline.getNextSibling().getNextSibling();
+
+        Assert.assertEquals(bundleOutline.getNextSibling().getTitle(), "Title (Document1a.pdf)");
+        Assert.assertEquals(bundleOutline.getNextSibling().getNextSibling().getTitle(), "Folder 1b");
+
+        bundleOutline = bundleOutline.getNextSibling().getNextSibling();
+
+        Assert.assertEquals(bundleOutline.getNextSibling().getTitle(), "Title (Document1b.pdf)");
+        Assert.assertEquals(bundleOutline.getNextSibling().getNextSibling().getTitle(), "Folder 2");
     }
 
     @Test
@@ -148,21 +138,16 @@ public class BundleOutlineScenarios extends BaseTest {
 
         PDOutlineItem bundleOutline = stitchedOutline.getFirstChild();
 
-        Assert.assertEquals(bundleOutline.getTitle(),
-                "Bundle Title");
-        Assert.assertEquals(bundleOutline.getFirstChild().getTitle(),
-                "Index Page");
-        Assert.assertEquals(bundleOutline.getFirstChild().getNextSibling().getTitle(),
-                "Title (Document 1)");
-        Assert.assertEquals(bundleOutline.getFirstChild().getNextSibling().getFirstChild().getTitle(),
+        Assert.assertEquals(bundleOutline.getTitle(), "Bundle Title");
+        Assert.assertEquals(bundleOutline.getNextSibling().getTitle(), "Index Page");
+        Assert.assertEquals(bundleOutline.getNextSibling().getNextSibling().getTitle(), "Title (Document 1)");
+        Assert.assertEquals(bundleOutline.getNextSibling().getNextSibling().getNextSibling().getTitle(),
                 documentWithOutline.getFirstChild().getTitle());
 
-        bundleOutline = bundleOutline.getFirstChild().getNextSibling().getNextSibling();
+        bundleOutline = bundleOutline.getNextSibling().getNextSibling().getNextSibling();
 
-        Assert.assertEquals(bundleOutline.getTitle(),
-                "Title (Document 2)");
-        Assert.assertEquals(bundleOutline.getNextSibling(),
-                null);
+        Assert.assertEquals(bundleOutline.getNextSibling().getTitle(),"Title (Document 2)");
+        Assert.assertEquals(bundleOutline.getNextSibling().getNextSibling(), null);
     }
 
     @Test
@@ -177,13 +162,13 @@ public class BundleOutlineScenarios extends BaseTest {
         PDOutlineItem bundleOutline = stitchedOutline.getFirstChild();
         final int bundlePage = getOutlinePage(bundleOutline);
 
-        PDOutlineItem tocOutline = bundleOutline.getFirstChild();
+        PDOutlineItem tocOutline = bundleOutline.getNextSibling();
         final int tocPage = getOutlinePage(tocOutline);
 
         PDOutlineItem firstDocumentCoverSheetOutline = tocOutline.getNextSibling();
         final int document1CoversheetPage = getOutlinePage(firstDocumentCoverSheetOutline);
 
-        PDOutlineItem firstDocumentFirstOutline = firstDocumentCoverSheetOutline.getFirstChild();
+        PDOutlineItem firstDocumentFirstOutline = firstDocumentCoverSheetOutline.getNextSibling();
         final int firstDocumentFirstPage = getOutlinePage(firstDocumentFirstOutline);
 
 
@@ -219,18 +204,14 @@ public class BundleOutlineScenarios extends BaseTest {
         PDOutlineItem bundleOutline = stitchedOutline.getFirstChild();
         final int bundlePage = getOutlinePage(bundleOutline);
 
-        PDOutlineItem outlineWithNoPage = bundleOutline.getFirstChild().getNextSibling().getFirstChild().getFirstChild();
+        PDOutlineItem outlineWithNoPage = bundleOutline.getNextSibling().getNextSibling().getNextSibling().getFirstChild();
         final int document1CoversheetPage = getOutlinePage(outlineWithNoPage);
 
         Files.delete(stitchedFile);
 
-        Assert.assertEquals(bundleOutline.getTitle(),
-                "Bundle Title");
-        Assert.assertEquals(bundlePage,
-                1);
-        Assert.assertEquals(outlineWithNoPage.getTitle(),
-                "Index Page");
-        Assert.assertEquals(document1CoversheetPage,
-                -1);
+        Assert.assertEquals(bundleOutline.getTitle(), "Bundle Title");
+        Assert.assertEquals(bundlePage, 1);
+        Assert.assertEquals(outlineWithNoPage.getTitle(), "Index Page");
+        Assert.assertEquals(document1CoversheetPage, -1);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
@@ -134,7 +134,13 @@ public class PDFMerger {
         private void addDocument(SortableBundleItem item) throws IOException {
             PDDocument newDoc = PDDocument.load(documents.get(item));
             final PDDocumentOutline newDocOutline = newDoc.getDocumentCatalog().getDocumentOutline();
-            pdfOutline.addItem(currentPageNumber - (bundle.hasCoversheets() ? 1 : 0), item.getTitle());
+
+            if (bundle.hasCoversheets()) {
+                pdfOutline.addItem(document.getNumberOfPages() - 1, item.getTitle());
+            } else if (newDocOutline != null){
+                PDOutlineItem outlineItem = pdfOutline.createHeadingItem(newDoc.getPage(0), item.getTitle());
+                newDocOutline.addFirst(outlineItem);
+            }
 
             try {
                 merger.appendDocument(document, newDoc);

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
@@ -72,6 +72,7 @@ public class PDFMerger {
             }
 
             addContainer(bundle);
+            pdfOutline.setRootOutlineItemDest();
 
             final File file = File.createTempFile("stitched", ".pdf");
             document.save(file);
@@ -137,7 +138,7 @@ public class PDFMerger {
 
             if (bundle.hasCoversheets()) {
                 pdfOutline.addItem(document.getNumberOfPages() - 1, item.getTitle());
-            } else if (newDocOutline != null){
+            } else if (newDocOutline != null) {
                 PDOutlineItem outlineItem = pdfOutline.createHeadingItem(newDoc.getPage(0), item.getTitle());
                 newDocOutline.addFirst(outlineItem);
             }

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
@@ -129,7 +129,7 @@ public class PDFMerger {
             addCenterText(document, page, item.getTitle(), 330);
 
             if (item.getSortedItems().count() > 0) {
-                pdfOutline.addParentItem(currentPageNumber, item.getTitle());
+                pdfOutline.addItem(currentPageNumber, item.getTitle());
             }
 
             currentPageNumber++;
@@ -138,7 +138,7 @@ public class PDFMerger {
         private void addDocument(SortableBundleItem item) throws IOException {
             PDDocument newDoc = PDDocument.load(documents.get(item));
             final PDDocumentOutline newDocOutline = newDoc.getDocumentCatalog().getDocumentOutline();
-            newDoc.getDocumentCatalog().setDocumentOutline(null);
+            pdfOutline.addItem(currentPageNumber - (bundle.hasCoversheets() ? 1 : 0), item.getTitle());
 
             try {
                 merger.appendDocument(document, newDoc);
@@ -169,12 +169,6 @@ public class PDFMerger {
             }
             if (tableOfContents != null && newDocOutline == null) {
                 tableOfContents.addDocument(item.getTitle(), currentPageNumber, newDoc.getNumberOfPages());
-
-            }
-
-            pdfOutline.addParentItem(currentPageNumber - (bundle.hasCoversheets() ? 1 : 0), item.getTitle());
-            if (newDocOutline != null) {
-                pdfOutline.mergeDocumentOutline(currentPageNumber, newDocOutline);
             }
             pdfOutline.closeParentItem();
             currentPageNumber += newDoc.getNumberOfPages();

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 import static org.springframework.util.StringUtils.isEmpty;
 import static uk.gov.hmcts.reform.em.stitching.pdf.PDFUtility.*;
 
-
 @Service
 public class PDFMerger {
     private static final String INDEX_PAGE = "Index Page";
@@ -73,9 +72,8 @@ public class PDFMerger {
             }
 
             addContainer(bundle);
-            pdfOutline.setRootOutlineItemDest(0);
-            final File file = File.createTempFile("stitched", ".pdf");
 
+            final File file = File.createTempFile("stitched", ".pdf");
             document.save(file);
             document.close();
 
@@ -89,7 +87,6 @@ public class PDFMerger {
                         addCoversheet(item);
                     }
                     addContainer(item);
-                    pdfOutline.closeParentItem();
                 } else if (documents.containsKey(item)) {
                     if (bundle.hasCoversheets()) {
                         addCoversheet(item);
@@ -131,7 +128,6 @@ public class PDFMerger {
             if (item.getSortedItems().count() > 0) {
                 pdfOutline.addItem(currentPageNumber, item.getTitle());
             }
-
             currentPageNumber++;
         }
 
@@ -170,7 +166,6 @@ public class PDFMerger {
             if (tableOfContents != null && newDocOutline == null) {
                 tableOfContents.addDocument(item.getTitle(), currentPageNumber, newDoc.getNumberOfPages());
             }
-            pdfOutline.closeParentItem();
             currentPageNumber += newDoc.getNumberOfPages();
             newDoc.close();
         }

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
@@ -1,13 +1,12 @@
 package uk.gov.hmcts.reform.em.stitching.pdf;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDPageDestination;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocumentOutline;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
+import java.awt.*;
 import java.util.Stack;
 
 public class PDFOutline {
@@ -36,59 +35,17 @@ public class PDFOutline {
         parentOutlineItems.firstElement().setDestination(document.getPage(page));
     }
 
-    public PDOutlineItem addItem(int page, String title) {
+    public void addItem(int page, String title) {
         PDOutlineItem outlineItem = new PDOutlineItem();
-        if (page > -1) {
-            outlineItem.setDestination(document.getPage(page));
-        }
+        outlineItem.setDestination(document.getPage(page));
         outlineItem.setTitle(title);
-        parentOutlineItems.peek().addLast(outlineItem);
-        parentOutlineItems.peek().openNode();
-
-        return outlineItem;
-    }
-
-    public void addParentItem(int page, String title) {
-        PDOutlineItem lastItem = addItem(page, title);
-        parentOutlineItems.push(lastItem);
+        outlineItem.setBold(true);
+        document.getDocumentCatalog().getDocumentOutline().addLast(outlineItem);
     }
 
     public void closeParentItem() {
         if (parentOutlineItems.size() > 1) {
             parentOutlineItems.pop();
-        }
-    }
-
-    public void mergeDocumentOutline(int currentPageNumber, PDDocumentOutline originalOutline) throws IOException {
-        PDOutlineItem item = originalOutline.getFirstChild();
-
-        while (item != null) {
-            item = copyDocumentOutline(currentPageNumber, item);
-        }
-    }
-
-    public PDOutlineItem copyDocumentOutline(int currentPageNumber, PDOutlineItem item) throws IOException {
-        int page = getOutlinePage(item);
-        PDOutlineItem outlineItem = addItem(page == -1 ? page : page + currentPageNumber, item.getTitle());
-        PDOutlineItem child = item.getFirstChild();
-        if (child != null) {
-            parentOutlineItems.push(outlineItem);
-            while (child != null) {
-                child = copyDocumentOutline(currentPageNumber, child);
-            }
-            parentOutlineItems.pop();
-        }
-        return item.getNextSibling();
-    }
-
-    public int getOutlinePage(PDOutlineItem outlineItem) {
-        PDPageDestination dest = null;
-        try {
-            dest = (PDPageDestination) outlineItem.getDestination();
-            return dest == null ? -1 : Math.max(dest.retrievePageNumber(), 0);
-        } catch (IOException e) {
-            log.error("Error message: " + e);
-            return -1;
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.em.stitching.pdf;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDPageDestination;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocumentOutline;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
 import org.slf4j.Logger;
@@ -26,6 +25,13 @@ public class PDFOutline {
         PDOutlineItem outlineItem = new PDOutlineItem();
         outlineItem.setTitle(title);
         bundleOutline.addLast(outlineItem);
+    }
+
+    public void setRootOutlineItemDest() {
+        PDOutlineItem rootElement = document.getDocumentCatalog().getDocumentOutline().getFirstChild();
+        if (rootElement != null) {
+            rootElement.setDestination(document.getPage(0));
+        }
     }
 
     public void addItem(int page, String title) {

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.em.stitching.pdf;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDPageDestination;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocumentOutline;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
 import org.slf4j.Logger;
@@ -32,5 +34,13 @@ public class PDFOutline {
         outlineItem.setTitle(title);
         outlineItem.setBold(true);
         document.getDocumentCatalog().getDocumentOutline().addLast(outlineItem);
+    }
+
+    public PDOutlineItem createHeadingItem(PDPage page, String title) {
+        PDOutlineItem outlineItem = new PDOutlineItem();
+        outlineItem.setTitle(title);
+        outlineItem.setDestination(page);
+        outlineItem.setBold(true);
+        return outlineItem;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
@@ -6,33 +6,24 @@ import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlin
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.awt.*;
-import java.util.Stack;
-
 public class PDFOutline {
 
     private final Logger log = LoggerFactory.getLogger(PDFOutline.class);
 
     private final PDDocument document;
-    private Stack<PDOutlineItem> parentOutlineItems = new Stack<>();
 
     public PDFOutline(PDDocument document) {
         this.document = document;
     }
 
     public void addBundleItem(String title) {
-        PDDocumentOutline parentOutline = new PDDocumentOutline();
-        document.getDocumentCatalog().setDocumentOutline(parentOutline);
-        parentOutline.openNode();
+        PDDocumentOutline bundleOutline = new PDDocumentOutline();
+        document.getDocumentCatalog().setDocumentOutline(bundleOutline);
+        bundleOutline.openNode();
 
-        PDOutlineItem parentOutlineItem = new PDOutlineItem();
-        parentOutlineItem.setTitle(title);
-        parentOutline.addLast(parentOutlineItem);
-        parentOutlineItems.push(parentOutlineItem);
-    }
-
-    public void setRootOutlineItemDest(int page) {
-        parentOutlineItems.firstElement().setDestination(document.getPage(page));
+        PDOutlineItem outlineItem = new PDOutlineItem();
+        outlineItem.setTitle(title);
+        bundleOutline.addLast(outlineItem);
     }
 
     public void addItem(int page, String title) {
@@ -41,11 +32,5 @@ public class PDFOutline {
         outlineItem.setTitle(title);
         outlineItem.setBold(true);
         document.getDocumentCatalog().getDocumentOutline().addLast(outlineItem);
-    }
-
-    public void closeParentItem() {
-        if (parentOutlineItems.size() > 1) {
-            parentOutlineItems.pop();
-        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/batch/DocumentTaskItemProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/batch/DocumentTaskItemProcessorTest.java
@@ -11,11 +11,9 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.util.Pair;
 import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.hmcts.reform.em.stitching.Application;
 import uk.gov.hmcts.reform.em.stitching.domain.Bundle;
 import uk.gov.hmcts.reform.em.stitching.domain.BundleDocument;
 import uk.gov.hmcts.reform.em.stitching.domain.BundleTest;
@@ -42,7 +40,6 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = Application.class)
 public class DocumentTaskItemProcessorTest {
 
     private static final String PDF_FILENAME = "annotationTemplate.pdf";

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpointValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpointValidatorTest.java
@@ -3,15 +3,12 @@ package uk.gov.hmcts.reform.em.stitching.domain.validation;
 import okhttp3.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.hmcts.reform.em.stitching.Application;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = Application.class)
 public class CallableEndpointValidatorTest {
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutlineTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutlineTest.java
@@ -48,10 +48,10 @@ public class PDFOutlineTest {
         document.addPage(new PDPage());
 
         pdfOutline.addBundleItem("Bundle");
-        pdfOutline.addParentItem(0, "Folder Item 1");
+        pdfOutline.addItem(0, "Folder Item 1");
         pdfOutline.addItem(0, "Sub Item 1");
         pdfOutline.closeParentItem();
-        pdfOutline.addParentItem(1, "Folder Item 2");
+        pdfOutline.addItem(1, "Folder Item 2");
         pdfOutline.addItem(1, "Sub Item 2");
         pdfOutline.closeParentItem();
         pdfOutline.setRootOutlineItemDest(0);
@@ -75,7 +75,7 @@ public class PDFOutlineTest {
         document.addPage(new PDPage());
 
         pdfOutline.addBundleItem("Bundle");
-        pdfOutline.addParentItem(0, "Folder Item 1");
+        pdfOutline.addItem(0, "Folder Item 1");
 
         PDDocument newDoc = new PDDocument();
         newDoc.addPage(new PDPage());
@@ -86,7 +86,6 @@ public class PDFOutlineTest {
         newDocOutline.addFirst(outlineItem);
         newDoc.getDocumentCatalog().setDocumentOutline(newDocOutline);
 
-        pdfOutline.mergeDocumentOutline(0, newDocOutline);
         pdfOutline.closeParentItem();
         pdfOutline.setRootOutlineItemDest(0);
 

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutlineTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutlineTest.java
@@ -31,7 +31,6 @@ public class PDFOutlineTest {
         document.addPage(new PDPage());
 
         pdfOutline.addBundleItem("Bundle");
-        pdfOutline.setRootOutlineItemDest(0);
 
         PDDocumentOutline documentOutline = document.getDocumentCatalog().getDocumentOutline();
 
@@ -50,11 +49,8 @@ public class PDFOutlineTest {
         pdfOutline.addBundleItem("Bundle");
         pdfOutline.addItem(0, "Folder Item 1");
         pdfOutline.addItem(0, "Sub Item 1");
-        pdfOutline.closeParentItem();
         pdfOutline.addItem(1, "Folder Item 2");
         pdfOutline.addItem(1, "Sub Item 2");
-        pdfOutline.closeParentItem();
-        pdfOutline.setRootOutlineItemDest(0);
 
         PDDocumentOutline documentOutline = document.getDocumentCatalog().getDocumentOutline();
         PDOutlineItem bundleOutline = documentOutline.getFirstChild();
@@ -85,9 +81,6 @@ public class PDFOutlineTest {
         outlineItem.setDestination(newDoc.getPage(0));
         newDocOutline.addFirst(outlineItem);
         newDoc.getDocumentCatalog().setDocumentOutline(newDocOutline);
-
-        pdfOutline.closeParentItem();
-        pdfOutline.setRootOutlineItemDest(0);
 
         PDDocumentOutline documentOutline = document.getDocumentCatalog().getDocumentOutline();
         PDOutlineItem bundleOutline = documentOutline.getFirstChild();

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutlineTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutlineTest.java
@@ -2,23 +2,20 @@ package uk.gov.hmcts.reform.em.stitching.pdf;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDPageDestination;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocumentOutline;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.hmcts.reform.em.stitching.Application;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.EmptyStackException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = Application.class)
 public class PDFOutlineTest {
     private static final File FILE_1 = new File(
             ClassLoader.getSystemResource("TEST_INPUT_FILE.pdf").getPath()
@@ -31,12 +28,13 @@ public class PDFOutlineTest {
         document.addPage(new PDPage());
 
         pdfOutline.addBundleItem("Bundle");
+        pdfOutline.setRootOutlineItemDest();
 
         PDDocumentOutline documentOutline = document.getDocumentCatalog().getDocumentOutline();
 
         assertEquals(documentOutline.getFirstChild().getTitle(), "Bundle");
-        assertNotEquals(documentOutline.getFirstChild().getDestination(), null);
-        assertNotEquals(documentOutline.getFirstChild(), null);
+        assertNotNull(documentOutline.getFirstChild().getDestination());
+        assertNotNull(documentOutline.getFirstChild());
     }
 
     @Test
@@ -48,51 +46,40 @@ public class PDFOutlineTest {
 
         pdfOutline.addBundleItem("Bundle");
         pdfOutline.addItem(0, "Folder Item 1");
-        pdfOutline.addItem(0, "Sub Item 1");
         pdfOutline.addItem(1, "Folder Item 2");
-        pdfOutline.addItem(1, "Sub Item 2");
+        pdfOutline.setRootOutlineItemDest();
 
         PDDocumentOutline documentOutline = document.getDocumentCatalog().getDocumentOutline();
         PDOutlineItem bundleOutline = documentOutline.getFirstChild();
 
-        assertNotEquals(bundleOutline, null);
+        assertNotNull(bundleOutline);
+        assertNotNull(bundleOutline.getDestination());
         assertEquals(bundleOutline.getTitle(), "Bundle");
-        assertNotEquals(bundleOutline.getDestination(), null);
-        assertEquals(bundleOutline.getFirstChild().getTitle(), "Folder Item 1");
-        assertEquals(bundleOutline.getFirstChild().getFirstChild().getTitle(), "Sub Item 1");
-        assertEquals(bundleOutline.getFirstChild().getNextSibling().getTitle(), "Folder Item 2");
-        assertEquals(bundleOutline.getFirstChild().getNextSibling().getFirstChild().getTitle(), "Sub Item 2");
+        assertEquals(bundleOutline.getNextSibling().getTitle(), "Folder Item 1");
+        assertEquals(bundleOutline.getNextSibling().getNextSibling().getTitle(), "Folder Item 2");
     }
 
     @Test
-    public void mergeOutlineFromAnotherDocument() throws IOException {
+    public void createHeadingItem() throws IOException {
         PDDocument document = new PDDocument();
         PDFOutline pdfOutline = new PDFOutline(document);
         document.addPage(new PDPage());
+        document.addPage(new PDPage());
 
         pdfOutline.addBundleItem("Bundle");
-        pdfOutline.addItem(0, "Folder Item 1");
-
-        PDDocument newDoc = new PDDocument();
-        newDoc.addPage(new PDPage());
-        PDDocumentOutline newDocOutline = new PDDocumentOutline();
-        PDOutlineItem outlineItem = new PDOutlineItem();
-        outlineItem.setTitle("New Doc Outline");
-        outlineItem.setDestination(newDoc.getPage(0));
-        newDocOutline.addFirst(outlineItem);
-        newDoc.getDocumentCatalog().setDocumentOutline(newDocOutline);
+        PDOutlineItem item = pdfOutline.createHeadingItem(document.getPage(0), "heading item");
+        document.getDocumentCatalog().getDocumentOutline().addFirst(item);
 
         PDDocumentOutline documentOutline = document.getDocumentCatalog().getDocumentOutline();
         PDOutlineItem bundleOutline = documentOutline.getFirstChild();
 
-        assertNotEquals(bundleOutline, null);
-        assertEquals(bundleOutline.getTitle(), "Bundle");
-        assertNotEquals(bundleOutline.getDestination(), null);
-        assertEquals(bundleOutline.getFirstChild().getTitle(), "Folder Item 1");
-        assertEquals(bundleOutline.getFirstChild().getFirstChild().getTitle(), "New Doc Outline");
+        assertNotNull(bundleOutline);
+        assertEquals("Bundle", bundleOutline.getNextSibling().getTitle());
+        assertEquals("heading item", bundleOutline.getTitle());
+        assertEquals(0, ((PDPageDestination) bundleOutline.getDestination()).retrievePageNumber());
     }
 
-    @Test(expected = EmptyStackException.class)
+    @Test(expected = IndexOutOfBoundsException.class)
     public void addItemWithInvalidPage() {
         PDDocument document = new PDDocument();
         PDFOutline pdfOutline = new PDFOutline(document);

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreUploaderImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreUploaderImplTest.java
@@ -5,10 +5,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.auth.checker.core.user.User;
-import uk.gov.hmcts.reform.em.stitching.Application;
 import uk.gov.hmcts.reform.em.stitching.domain.Bundle;
 import uk.gov.hmcts.reform.em.stitching.domain.BundleTest;
 import uk.gov.hmcts.reform.em.stitching.domain.DocumentTask;
@@ -18,7 +16,6 @@ import java.io.File;
 import java.util.HashSet;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = Application.class)
 public class DmStoreUploaderImplTest {
 
     DmStoreUploader dmStoreUploader;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-3045

### Change description ###
fix issue with document outline during stitching by retaining original outline

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
