### PR TITLE
Updating Log4j version to 2.17.0 because of CVE-2021-45105 vulnerability.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ def versions = [
         gradlePitest       : '1.3.0',
         postgresql         : '42.2.20',
         shedlock           : '4.28.0',
-        log4JVersion       : '2.16.0'
+        log4JVersion       : '2.17.0'
 ]
 
 pitest {


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Update Log4j version to 2.17.0
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
