### PR TITLE
Updated server port for local config only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -574,7 +574,7 @@ bootWithCCD {
     }
     environment 'ENABLE_LIQUIBASE', true
     environment 'RSE_LIB_ADDITIONAL_DATABASES', 'emstitch'
-    environment 'DATA_STORE_S2S_AUTHORISED_SERVICES', 'ccd_gw,ccd_data,ccd_ps,aac_manage_case_assignment,ccd_case_document_am_api,am_role_assignment_service,hmc_cft_hearing_service,prl_citizen_frontend,xui_webapp'
+    environment 'DATA_STORE_S2S_AUTHORISED_SERVICES', 'ccd_gw,ccd_data,ccd_ps,aac_manage_case_assignment,ccd_case_document_am_api,am_role_assignment_service,hmc_cft_hearing_service,prl_citizen_frontend,xui_webapp,em_ccd_orchestrator'
     environment 'S2S_URL', 'http://rpe-service-auth-provider-aat.service.core-compute-aat.internal'
     environment 'CASE_DOCUMENT_AM_API_S2S_SECRET','${CASE_DOCUMENT_AM_API_S2S_SECRET}'
     authMode = uk.gov.hmcts.rse.AuthMode.AAT

--- a/src/aat/resources/application.yml
+++ b/src/aat/resources/application.yml
@@ -26,7 +26,7 @@ management:
           - info
 
 test:
-  url: ${TEST_URL:http://localhost:8080}
+  url: ${TEST_URL:http://localhost:4630}
 
 idam:
   api:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,5 @@
+server:
+  port: 4630
 spring:
   application:
     name: EM Stitching API


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-4470
### Change description ###
Updated server port for local config only. This is make sure we run all dependencies for Bundling in Stitching API. And bootRun em-ccd-orchestrator locally with out any of it's dependencies been run in docker.
**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
