### PR TITLE
fix test - fix master pipeline

### DIFF
--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/BundleOptionScenarios.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/BundleOptionScenarios.java
@@ -5,6 +5,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import uk.gov.hmcts.reform.em.stitching.service.dto.BundleDTO;
 import uk.gov.hmcts.reform.em.test.retry.RetryRule;
 
@@ -20,21 +21,25 @@ public class BundleOptionScenarios extends BaseTest  {
     private final File document3 = new File(ClassLoader.getSystemResource("five-hundred-page.pdf").getPath());
     private final File document4 = new File(ClassLoader.getSystemResource("annotationTemplate.pdf").getPath());
     private final File document5 = new File(ClassLoader.getSystemResource("SamplePDF_special_characters.pdf").getPath());
+    private File stitchedFile;
 
     @Rule
     public RetryRule retryRule = new RetryRule(3);
+
+    @AfterEach
+    void clear(){
+        FileUtils.deleteQuietly(stitchedFile);
+    }
 
     @Test
     public void testDefaultValuesForTableOfContentsAndCoversheets() throws IOException, InterruptedException {
         final BundleDTO bundle = testUtil.getTestBundleWithOnePageDocuments();
         final Response response = testUtil.processBundle(bundle);
         final String stitchedDocumentUri = response.getBody().jsonPath().getString("bundle.stitchedDocumentURI");
-        final File stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
+        stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
         final int numExtraPages = 3;
         final int expectedPages = getNumPages(document1) + getNumPages(document2) + numExtraPages;
         final int actualPages = getNumPages(stitchedFile);
-
-        FileUtils.deleteQuietly(stitchedFile);
 
         Assert.assertEquals(expectedPages, actualPages);
     }
@@ -46,12 +51,10 @@ public class BundleOptionScenarios extends BaseTest  {
         bundle.setHasCoversheets(true);
         final Response response = testUtil.processBundle(bundle);
         final String stitchedDocumentUri = response.getBody().jsonPath().getString("bundle.stitchedDocumentURI");
-        final File stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
+        stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
         final int numExtraPages = 2;
         final int expectedPages = getNumPages(document1) + getNumPages(document2) + numExtraPages;
         final int actualPages = getNumPages(stitchedFile);
-
-        FileUtils.deleteQuietly(stitchedFile);
 
         Assert.assertEquals(expectedPages, actualPages);
     }
@@ -63,12 +66,10 @@ public class BundleOptionScenarios extends BaseTest  {
         bundle.setHasCoversheets(false);
         final Response response = testUtil.processBundle(bundle);
         final String stitchedDocumentUri = response.getBody().jsonPath().getString("bundle.stitchedDocumentURI");
-        final File stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
+        stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
         final int numExtraPages = 1;
         final int expectedPages = getNumPages(document1) + getNumPages(document2) + numExtraPages;
         final int actualPages = getNumPages(stitchedFile);
-
-        FileUtils.deleteQuietly(stitchedFile);
 
         Assert.assertEquals(expectedPages, actualPages);
     }
@@ -80,12 +81,10 @@ public class BundleOptionScenarios extends BaseTest  {
         bundle.setHasTableOfContents(false);
         final Response response = testUtil.processBundle(bundle);
         final String stitchedDocumentUri = response.getBody().jsonPath().getString("bundle.stitchedDocumentURI");
-        final File stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
+        stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
         final int numExtraPages = 0;
         final int expectedPages = getNumPages(document1) + getNumPages(document2) + numExtraPages;
         final int actualPages = getNumPages(stitchedFile);
-
-        FileUtils.deleteQuietly(stitchedFile);
 
         Assert.assertEquals(expectedPages, actualPages);
     }
@@ -96,12 +95,10 @@ public class BundleOptionScenarios extends BaseTest  {
         final BundleDTO bundle = testUtil.getTestBundleWithLargeToc();
         final Response response = testUtil.processBundle(bundle);
         final String stitchedDocumentUri = response.getBody().jsonPath().getString("bundle.stitchedDocumentURI");
-        final File stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
+        stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
         final int numExtraPages = 17;
         final int expectedPages = getNumPages(document3) + getNumPages(document4) + getNumPages(document5) + numExtraPages;
         final int actualPages = getNumPages(stitchedFile);
-
-        FileUtils.deleteQuietly(stitchedFile);
 
         Assert.assertEquals(expectedPages, actualPages);
     }

--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/BundleOptionScenarios.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/BundleOptionScenarios.java
@@ -27,7 +27,7 @@ public class BundleOptionScenarios extends BaseTest  {
     public RetryRule retryRule = new RetryRule(3);
 
     @AfterEach
-    void clear(){
+    void clear() {
         FileUtils.deleteQuietly(stitchedFile);
     }
 

--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/BundleOutlineScenarios.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/BundleOutlineScenarios.java
@@ -6,6 +6,7 @@ import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocume
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import uk.gov.hmcts.reform.em.stitching.service.dto.BundleDTO;
 import uk.gov.hmcts.reform.em.test.retry.RetryRule;
 
@@ -22,20 +23,24 @@ public class BundleOutlineScenarios extends BaseTest {
     private final File onePageDocument = new File(ClassLoader.getSystemResource("one-page.pdf").getPath());
     private final File hundredPageDocument = new File(ClassLoader.getSystemResource("hundred-page.pdf").getPath());
     private static final String STITCHED_DOCUMENT_URI = "bundle.stitchedDocumentURI";
+    private File stitchedFile;
 
     @Rule
     public RetryRule retryRule = new RetryRule(3);
+
+    @AfterEach
+    void clear(){
+        FileUtils.deleteQuietly(stitchedFile);
+    }
 
     @Test
     public void testStitchBundleWithNoOutlines() throws IOException, InterruptedException {
         final BundleDTO bundle = testUtil.getTestBundleWithOnePageDocuments();
         final Response response = testUtil.processBundle(bundle);
         final String stitchedDocumentUri = response.getBody().jsonPath().getString(STITCHED_DOCUMENT_URI);
-        final File stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
+        stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
 
         final PDDocumentOutline stitchedOutline = getDocumentOutline(stitchedFile);
-
-        FileUtils.deleteQuietly(stitchedFile);
 
         final PDOutlineItem bundleOutline = stitchedOutline.getFirstChild();
 
@@ -50,11 +55,9 @@ public class BundleOutlineScenarios extends BaseTest {
         final BundleDTO bundle = testUtil.getTestBundle();
         final Response response = testUtil.processBundle(bundle);
         final String stitchedDocumentUri = response.getBody().jsonPath().getString(STITCHED_DOCUMENT_URI);
-        final File stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
+        stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
 
         final PDDocumentOutline stitchedOutline = getDocumentOutline(stitchedFile);
-
-        FileUtils.deleteQuietly(stitchedFile);
 
         final PDOutlineItem bundleOutline = stitchedOutline.getFirstChild();
 
@@ -70,11 +73,9 @@ public class BundleOutlineScenarios extends BaseTest {
 
         final Response response = testUtil.processBundle(bundle);
         final String stitchedDocumentUri = response.getBody().jsonPath().getString(STITCHED_DOCUMENT_URI);
-        final File stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
+        stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
 
         final PDDocumentOutline stitchedOutline = getDocumentOutline(stitchedFile);
-
-        FileUtils.deleteQuietly(stitchedFile);
 
         final PDOutlineItem bundleOutline = stitchedOutline.getFirstChild();
 
@@ -96,11 +97,9 @@ public class BundleOutlineScenarios extends BaseTest {
 
         final Response response = testUtil.processBundle(bundle);
         final String stitchedDocumentUri = response.getBody().jsonPath().getString(STITCHED_DOCUMENT_URI);
-        final File stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
+        stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
 
         final PDDocumentOutline stitchedOutline = getDocumentOutline(stitchedFile);
-
-        FileUtils.deleteQuietly(stitchedFile);
 
         PDOutlineItem bundleOutline = stitchedOutline.getFirstChild();
 
@@ -133,11 +132,9 @@ public class BundleOutlineScenarios extends BaseTest {
         final BundleDTO bundle = testUtil.getTestBundleWithOneDocumentWithAOutline();
         final Response response = testUtil.processBundle(bundle);
         final String stitchedDocumentUri = response.getBody().jsonPath().getString(STITCHED_DOCUMENT_URI);
-        final File stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
+        stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
 
         final PDDocumentOutline stitchedOutline = getDocumentOutline(stitchedFile);
-
-        FileUtils.deleteQuietly(stitchedFile);
 
         PDOutlineItem bundleOutline = stitchedOutline.getFirstChild();
 
@@ -154,7 +151,7 @@ public class BundleOutlineScenarios extends BaseTest {
         final BundleDTO bundle = testUtil.getTestBundle();
         final Response response = testUtil.processBundle(bundle);
         final String stitchedDocumentUri = response.getBody().jsonPath().getString(STITCHED_DOCUMENT_URI);
-        final File stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
+        stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
 
         final PDDocumentOutline stitchedOutline = getDocumentOutline(stitchedFile);
 
@@ -169,9 +166,6 @@ public class BundleOutlineScenarios extends BaseTest {
 
         PDOutlineItem secondDocumentFirstOutline = tocOutline.getNextSibling().getNextSibling();
         final int secondDocumentFirstPage = getOutlinePage(secondDocumentFirstOutline);
-
-
-        FileUtils.deleteQuietly(stitchedFile);
 
         assertEquals("Bundle Title", bundleOutline.getTitle());
         assertEquals(1, bundlePage);
@@ -188,7 +182,7 @@ public class BundleOutlineScenarios extends BaseTest {
         final BundleDTO bundle = testUtil.getTestBundleOutlineWithNoDestination();
         final Response response = testUtil.processBundle(bundle);
         final String stitchedDocumentUri = response.getBody().jsonPath().getString(STITCHED_DOCUMENT_URI);
-        final File stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
+        stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
 
         final PDDocumentOutline stitchedOutline = getDocumentOutline(stitchedFile);
 
@@ -197,8 +191,6 @@ public class BundleOutlineScenarios extends BaseTest {
 
         PDOutlineItem outlineWithNoPage = bundleOutline.getFirstChild();
         final int document1CoversheetPage = getOutlinePage(outlineWithNoPage);
-
-        FileUtils.deleteQuietly(stitchedFile);
 
         assertEquals("Bundle Title", bundleOutline.getTitle());
         assertEquals(1, bundlePage);

--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/BundleOutlineScenarios.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/BundleOutlineScenarios.java
@@ -29,7 +29,7 @@ public class BundleOutlineScenarios extends BaseTest {
     public RetryRule retryRule = new RetryRule(3);
 
     @AfterEach
-    void clear(){
+    void clear() {
         FileUtils.deleteQuietly(stitchedFile);
     }
 


### PR DESCRIPTION
before assertion it is deleting the file, it may affect the result. 

`failing flaky test, it only fails in Master build.

15:58:21  uk.gov.hmcts.reform.em.stitching.functional.BundleOutlineScenarios > testStitchBundleWithOnlyOneDocumentOutline FAILED
15:58:21      java.lang.NullPointerException: Cannot invoke "org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem.getTitle()" because the return value of "org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem.getFirstChild()" is null
15:58:21          at uk.gov.hmcts.reform.em.stitching.functional.BundleOutlineScenarios.testStitchBundleWithOnlyOneDocumentOutline(BundleOutlineScenarios.java:145)
`