### PR TITLE
Changed method merge for the file to take the bundle name

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
@@ -83,7 +83,7 @@ public class PDFMerger {
 
                 pdfOutline.setRootOutlineItemDest();
 
-                final File file = File.createTempFile("stitched", ".pdf");
+                final File file = File.createTempFile(bundle.getFileName(), "pdf");
                 document.save(file);
                 return file;
             } finally {


### PR DESCRIPTION
### JIRA link (if applicable) ###

[https://tools.hmcts.net/jira/browse/EM-5074](url)

### Change description ###

Correct file name when downloading bundle

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
