### PR TITLE
 EM-5145 fix getOutlinePage , ignore Nameddestinations

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
@@ -182,7 +182,7 @@ public class PDFOutline {
             if (pdDestination instanceof PDPageDestination) {
                 var dest = (PDPageDestination) pdDestination;
                 log.info("outlineItem Title: {}, destination is null : {}" + outlineItem.getTitle(), (dest == null));
-                return dest == null ? -1 : Math.max(dest.retrievePageNumber(), 0);
+                return Math.max(dest.retrievePageNumber(), 0);
             }
         } catch (Exception e) {
             log.error("GetOutlinePage Error message: " + e);

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
@@ -5,6 +5,7 @@ import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.cos.COSNull;
 import org.apache.pdfbox.multipdf.PDFCloneUtility;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDDestination;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDPageDestination;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocumentOutline;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
@@ -145,8 +146,7 @@ public class PDFOutline {
 
         //document coversheet outline or doc outline should already be there.
         destLastOutlineItem = findPdOutlineItem(destLastOutlineItem, key);
-        for (PDOutlineItem item : srcOutline.children())
-        {
+        for (PDOutlineItem item : srcOutline.children()) {
             // get each child, clone its dictionary, remove siblings info,
             // append outline item created from there
             COSDictionary clonedDict = (COSDictionary) cloner.cloneForNewDocument(item);
@@ -178,7 +178,9 @@ public class PDFOutline {
 
     public int getOutlinePage(PDOutlineItem outlineItem) {
         try {
-            if (outlineItem.getDestination() instanceof PDPageDestination dest) {
+            PDDestination pdDestination = outlineItem.getDestination();
+            if (pdDestination instanceof PDPageDestination) {
+                var dest = (PDPageDestination) pdDestination;
                 log.info("outlineItem Title: {}, destination is null : {}" + outlineItem.getTitle(), (dest == null));
                 return dest == null ? -1 : Math.max(dest.retrievePageNumber(), 0);
             }

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
@@ -181,7 +181,7 @@ public class PDFOutline {
             PDDestination pdDestination = outlineItem.getDestination();
             if (pdDestination instanceof PDPageDestination) {
                 var dest = (PDPageDestination) pdDestination;
-                log.info("outlineItem Title: {}, destination is null : {}" + outlineItem.getTitle(), (dest == null));
+                log.info("outlineItem Title: {}}" + outlineItem.getTitle());
                 return Math.max(dest.retrievePageNumber(), 0);
             }
         } catch (Exception e) {

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
@@ -177,15 +177,15 @@ public class PDFOutline {
     }
 
     public int getOutlinePage(PDOutlineItem outlineItem) {
-        PDPageDestination dest = null;
         try {
-            dest = (PDPageDestination) outlineItem.getDestination();
-            log.info("outlineItem Title: {}, destination is null : {}" + outlineItem.getTitle(), (dest == null));
-            return dest == null ? -1 : Math.max(dest.retrievePageNumber(), 0);
-        } catch (IOException e) {
-            log.error("Error message: " + e);
-            return -1;
+            if (outlineItem.getDestination() instanceof PDPageDestination dest) {
+                log.info("outlineItem Title: {}, destination is null : {}" + outlineItem.getTitle(), (dest == null));
+                return dest == null ? -1 : Math.max(dest.retrievePageNumber(), 0);
+            }
+        } catch (Exception e) {
+            log.error("GetOutlinePage Error message: " + e);
         }
+        return -1;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFOutline.java
@@ -181,7 +181,7 @@ public class PDFOutline {
             PDDestination pdDestination = outlineItem.getDestination();
             if (pdDestination instanceof PDPageDestination) {
                 var dest = (PDPageDestination) pdDestination;
-                log.info("outlineItem Title: {}}" + outlineItem.getTitle());
+                log.info("outlineItem Title: {}, destination is null : {}" + outlineItem.getTitle(), (dest == null));
                 return Math.max(dest.retrievePageNumber(), 0);
             }
         } catch (Exception e) {


### PR DESCRIPTION
[EM-5145](https://tools.hmcts.net/jira/browse/EM-5145)fix getOutlinePage , ignore Nameddestinations

Currently we can support page number as destination for now Ignoring Nameddestinations