### PR TITLE
add graceful shutdown

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,6 @@
 server:
   port: 4630
+  shutdown: graceful
 spring:
   application:
     name: EM Stitching API


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/EM-5788


### Change description ###
add graceful shutdown using default value of 30s for spring timeout and kubernetes grace period

