### PR TITLE
EM-6284 increase retry count

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/config/BatchConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/config/BatchConfiguration.java
@@ -52,7 +52,7 @@ public class BatchConfiguration {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BatchConfiguration.class);
 
-    public static int DOCUMENT_TASK_RETRY_COUNT = 3;
+    public static int DOCUMENT_TASK_RETRY_COUNT = 4;
 
     @Autowired
     PlatformTransactionManager transactionManager;


### PR DESCRIPTION
 increase retry count,
https://tools.hmcts.net/jira/browse/EM-6284 some documents marked as failed event they are successful. Incresing the retry count until we found the root cause.