### PR TITLE
Updated defaultLockAtMostFor

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/config/BatchConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/config/BatchConfiguration.java
@@ -51,7 +51,7 @@ import javax.sql.DataSource;
 
 @EnableBatchProcessing
 @EnableScheduling
-@EnableSchedulerLock(defaultLockAtMostFor = "PT3M", defaultLockAtLeastFor = "PT5S")
+@EnableSchedulerLock(defaultLockAtMostFor = "PT5M", defaultLockAtLeastFor = "PT5S")
 @Configuration
 @ConditionalOnProperty(name = "scheduling.enabled")
 public class BatchConfiguration {


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/EM-6295
### Change description
Investigation revealed that when a Batch job takes more than 3 minutes to complete. Sched Lock is released after 3 minutes which then means same row from DB is picked up by another batch job. We are increasing the defaultLockAtMostFor to 5 minutes assuming most of the jobs are completed with in this 5 minutes window.
### Testing done
N/A
### Checklist
- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
