### PR TITLE
EM-7226 Add suppressions for CVE-2026-54399 and CVE-2026-54428

### DIFF
--- a/config/owasp/dependency-check-suppressions.xml
+++ b/config/owasp/dependency-check-suppressions.xml
@@ -29,4 +29,9 @@
         <gav regex="true">^org\.jetbrains\.kotlin:kotlin-stdlib:.*$</gav>
         <cve>CVE-2026-53914</cve>
     </suppress>
+    <suppress until="2026-10-07Z">
+        <gav regex="true">^org\.apache\.httpcomponents:httpcore:.*$</gav>
+        <cve>CVE-2026-54399</cve>
+        <cve>CVE-2026-54428</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
[EM-7226](https://tools.hmcts.net/jira/browse/EM-7226) suppress for https://github.com/advisories/GHSA-hf6x-8p5f-cgmf and https://github.com/advisories/GHSA-v3jc-474w-2wm6